### PR TITLE
Fix direction information

### DIFF
--- a/src/vr_poll.coffee
+++ b/src/vr_poll.coffee
@@ -44,7 +44,7 @@ class VRPollClient
                         label: info.guid
                     trip:
                         route: route_to_code(info.title)
-                        direction: if info.startStation == "HKI" then "1" else "2"
+                        direction: if info.from == "HKI" then "1" else "2"
                         start_time: extended_info.item[0].scheduledDepartTime.replace ':', ''
                         operator: "HSL"
                     position:


### PR DESCRIPTION
Currently the field where the first station is stored is called startStation in the getTrain respone and from in getTrains resopnse. Fix by reading the right field from the right response.
